### PR TITLE
Length of break in seconds and option to disable notifications

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -62,7 +62,7 @@ angular.module('BreakTime', [])
 
       var working = moment().add(
         chrome.extension.getBackgroundPage().config.length,
-        'minutes'
+        'seconds'
       );
 
       $scope.toggleBreaksOn = function() {
@@ -206,7 +206,7 @@ angular.module('BreakTime', [])
       $scope.backgroundColor = ConfigService.config.backgroundColor;
       $scope.textColor = ConfigService.config.textColor;
       $scope.allowEndBreak = ConfigService.config.allowEndBreak;
-      var breakEnd = moment().add(ConfigService.config.length, 'minutes');
+      var breakEnd = moment().add(ConfigService.config.length, 'seconds');
 
       $scope.skip = function() {
         chrome.runtime.sendMessage({event: "endBreak"});

--- a/js/background.js
+++ b/js/background.js
@@ -349,6 +349,10 @@ function checkTimeStayMinutes() {
     chrome.browserAction.setBadgeBackgroundColor({
       color: "#F00"
     });
+  } else {
+    chrome.browserAction.setBadgeBackgroundColor({
+      color: "#008000"
+    });
   }
 }
 

--- a/js/background.js
+++ b/js/background.js
@@ -10,7 +10,7 @@ var isFirefox = navigator.userAgent.indexOf("Firefox") > -1
 
 var defaultConfig = {
   frequency: 28,
-  length: 2,
+  length: 120,
   postpone: 3,
   notificationType: 'F',
   workingHoursFrom: '09:00',

--- a/js/background.js
+++ b/js/background.js
@@ -60,7 +60,8 @@ var defaultConfig = {
   allowEndBreak: true,
   allowSkipBreak: true,
   allowPostponeBreak: true,
-  allowNotifications: true
+  allowNotifications: true,
+  allowIconTimeToBreak: false
 };
 
 // Grab config from local storage mergded with defaultConfig
@@ -274,10 +275,12 @@ function startBreak() {
 }
 
 function endBreak() {
+  if (config.allowIconTimeToBreak) {
   restIndicatorLeft = Math.floor(config.frequency);
    chrome.browserAction.setBadgeText({
      text: restIndicatorLeft.toString()
    });
+  }
   chrome.windows.remove(breakId)
 }
 
@@ -332,27 +335,29 @@ function checkIdleMinutes() {
 }
 
 function checkTimeStayMinutes() {
-  // Check if indicator icon is greater then one minute
-  console.log("extension test");
-  if (typeof(restIndicatorLeft) === 'undefined') {
-    restIndicatorStart = moment();
-    restIndicatorLeft = Number(Math.floor(config.frequency) - 1);
-    restIndicatorPrecise = restIndicatorStart.clone().add(restIndicatorLeft, 'minutes')
-  } else {
-      restIndicatorLeft = restIndicatorLeft-1
-  }
-  console.log(restIndicatorLeft);
-  chrome.browserAction.setBadgeText({
-    text: restIndicatorLeft.toString()
-  });
-  if (restIndicatorLeft < 0){
-    chrome.browserAction.setBadgeBackgroundColor({
-      color: "#F00"
+  if (config.allowIconTimeToBreak) {
+    // Check if indicator icon is greater then one minute
+    console.log("extension test");
+    if (typeof(restIndicatorLeft) === 'undefined') {
+      restIndicatorStart = moment();
+      restIndicatorLeft = Number(Math.floor(config.frequency) - 1);
+      restIndicatorPrecise = restIndicatorStart.clone().add(restIndicatorLeft, 'minutes')
+    } else {
+      restIndicatorLeft = restIndicatorLeft - 1
+    }
+    console.log(restIndicatorLeft);
+    chrome.browserAction.setBadgeText({
+      text: restIndicatorLeft.toString()
     });
-  } else {
-    chrome.browserAction.setBadgeBackgroundColor({
-      color: "#008000"
-    });
+    if (restIndicatorLeft < -1) {
+      chrome.browserAction.setBadgeBackgroundColor({
+        color: "#F00"
+      });
+    } else {
+      chrome.browserAction.setBadgeBackgroundColor({
+        color: "#008000"
+      });
+    }
   }
 }
 

--- a/js/background.js
+++ b/js/background.js
@@ -57,6 +57,7 @@ var defaultConfig = {
   allowEndBreak: true,
   allowSkipBreak: true,
   allowPostponeBreak: true,
+  allowNotifications: true
 };
 
 // Grab config from local storage mergded with defaultConfig
@@ -127,17 +128,20 @@ function createFullscreenNotification() {
       }
     }
 
-    chrome.notifications.create(
-      'countdown',
-      notificationOptions,
-      function(newNotificationId) {
-        countdownId = newNotificationId;
+    if(config.allowNotifications){
+      chrome.notifications.create(
+        'countdown',
+        notificationOptions,
+        function(newNotificationId) {
+          countdownId = newNotificationId;
 
-        fullscreenTimeout = setTimeout(function() {
-          createFullscreen();
-        }, 10000);
-      });
-
+          fullscreenTimeout = setTimeout(function() {
+            createFullscreen();
+          }, 10000);
+        });
+    } else {
+      createFullscreen();
+    }
   } else {
 
     // Unfortunately, more advanced options are currently unimplemented in
@@ -148,18 +152,21 @@ function createFullscreenNotification() {
       title: config.breakText,
       message: 'Break about to start...'
     };
+    if (config.allowNotifications) {
+      browser.notifications.create(
+        'countdown',
+        notificationOptions,
+        function(newNotificationId) {
+          countdownId = newNotificationId;
 
-    browser.notifications.create(
-      'countdown',
-      notificationOptions,
-      function(newNotificationId) {
-        countdownId = newNotificationId;
-
-        setTimeout(function() {
-          createFullscreen();
-        }, 5000);
-      });
-
+          setTimeout(function() {
+            createFullscreen();
+          }, 5000);
+        }
+      );
+    } else {
+      createFullscreen();
+    }
   }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "name": "Break Timer",
   "description": "Enforce periodic breaks to prevent RSI / eye strain.",
   "icons": {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -64,7 +64,7 @@ body {
                                        class="form-control checkbox" ng-model="config.gongEnabled"/>
               </div>
               <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">
-                <label for="allow-notifications">Allow Notifications</label>
+                <label for="allow-notifications">Allow Notification Before Break</label>
                 <input type="checkbox" id="allow-notifications" class="form-control checkbox" ng-model="config.allowNotifications" />
               </div>
               <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -107,6 +107,11 @@ body {
                 <input type="text" id="break-message" class="form-control"
                                                       ng-model="config.breakMessage"/>
               </div>
+              <div class="form-group" ng-show="config.notificationType === 'F'">
+                <label for="allow-minutes-remaining-in-icon">Show Minutes Remaining To The Next Break In Extension Icon</label>
+                <input type="checkbox" id="allow-minutes-remaining-in-icon"
+                                       class="form-control checkbox" ng-model="config.allowIconTimeToBreak"/>
+              </div>
             </div>
           </div>
           <div class="row">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -64,12 +64,16 @@ body {
                                        class="form-control checkbox" ng-model="config.gongEnabled"/>
               </div>
               <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">
-                <label for="allow-skip-postpone-break">Allow Skip Break</label>
+                <label for="allow-notification">Allow Notifications</label>
+                <input type="checkbox" id="allow-notifications" class="form-control checkbox" ng-model="config.allowNotifications" />
+              </div>
+              <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">
+                <label for="allow-skip-postpone-break">Allow Skip Break (in notification)</label>
                 <input type="checkbox" id="allow-skip-postpone-break"
                                        class="form-control checkbox" ng-model="config.allowSkipBreak"/>
               </div>
               <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">
-                <label for="allow-skip-postpone-break">Allow Postpone Break</label>
+                <label for="allow-skip-postpone-break">Allow Postpone Break(in notification)</label>
                 <input type="checkbox" id="allow-skip-postpone-break"
                                        class="form-control checkbox" ng-model="config.allowPostponeBreak"/>
               </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -64,7 +64,7 @@ body {
                                        class="form-control checkbox" ng-model="config.gongEnabled"/>
               </div>
               <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">
-                <label for="allow-notification">Allow Notifications</label>
+                <label for="allow-notifications">Allow Notifications</label>
                 <input type="checkbox" id="allow-notifications" class="form-control checkbox" ng-model="config.allowNotifications" />
               </div>
               <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -51,7 +51,7 @@ body {
               <div class="form-group" ng-show="config.notificationType === 'F'">
                 <label for="break-length">Break length</label>
                 <input type="number" id="break-length" class="form-control min-input"
-                                                       ng-model="config.length" required/> <span>minutes</span>
+                                                       ng-model="config.length" required/> <span>seconds</span>
               </div>
               <div class="form-group" ng-show="config.notificationType === 'F' && !isFirefox">
                 <label for="postpone-length">Postpone length</label>


### PR DESCRIPTION
First commit should fix https://github.com/tom-james-watson/breaktimer/issues/2 in simplest form.
Second gives option to not shows notification to the users, that not want such notification.
First change is simple, but requires users to update their preferences (because their previous stored minutes are now seconds).
Option to disable notifications is for uses that not like to be notified, so just show them break window without notification(postpone and skip are not available in this scenario).